### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ steps:
     artifacts: "pool/stretch-amd64/*"
   - wait
   - plugins:
-      opx-infra/smoke-test#v0.1.0:
-        download: pool/stretch-amd64
-        distribution: stretch
+      - opx-infra/smoke-test#v0.1.0:
+          download: pool/stretch-amd64
+          distribution: stretch
 ```
 
 ## Configuration


### PR DESCRIPTION
Hi @theucke! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.